### PR TITLE
#28 Settings Implementation: Automatically start Timer on start

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@ This document tracks changes parallel to development and contains unreleased cha
     * Start App with Windows: Allows the app to be started with Windows.
     * Hide Window Automatically: Hide the window automatically as soon as you lose focus.
     * Automatically start new Timer after every stopped one
+    * Automatically start Timer on start
 ### Bug Fixes
 * End time is now always set to `now-1` to align with the start time of the next timer.
 * Start and End time are now saved in 24h format.

--- a/Time Tracker/MainWindow.xaml.cs
+++ b/Time Tracker/MainWindow.xaml.cs
@@ -81,6 +81,12 @@ namespace Time_Tracker
         private void Window_Loaded(object sender, RoutedEventArgs e)
         {
             this.Visibility = Visibility.Collapsed;
+
+            if (oSettings.bAutomaticallyStartTimerOnStart)
+            {
+                //Start new timer 
+                UiStart_Click(null, null);
+            }
         }
 
         private void Window_Closing(object sender, System.ComponentModel.CancelEventArgs e)

--- a/Time Tracker/Resources/Classes/Settings.cs
+++ b/Time Tracker/Resources/Classes/Settings.cs
@@ -11,6 +11,7 @@ namespace Time_Tracker.Resources.Classes
         public bool bStartWithWindows = false;
         public bool bHideWindowAutomatically = true;
         public bool bAutomaticallyStartNewTimer = true;
+        public bool bAutomaticallyStartTimerOnStart = false;
 
         public Settings(string sSettingsFilePath)
         {


### PR DESCRIPTION
As soon as the app is loaded a timer starts, if the corresponding setting is set.

Resolves #28